### PR TITLE
Add simple agent modules for WhatsApp LMS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,7 @@ making it ideal for local deployments, especially in environments with limited r
 Local Area Network (LAN): The system will be designed to operate over a Local Area Network, ensuring full functionality in environments with 
 limited or no internet connectivity. This setup is particularly advantageous for schools with existing computer labs, allowing them to deploy 
 the LLMS effectively and reliably. -> Can use a flash drive delivery method.
+
+
+## Oasis LMS via WhatsApp
+Oasis LMS in `services/oasis_lms` is a small FastAPI service that provides a WhatsApp-based learning interface. It uses a collection of "smol" agents for tasks like progress tracking, quiz generation, and teacher broadcasts. See `services/oasis_lms/README.md` for setup details.

--- a/readme.md
+++ b/readme.md
@@ -71,4 +71,4 @@ the LLMS effectively and reliably. -> Can use a flash drive delivery method.
 
 
 ## Oasis LMS via WhatsApp
-Oasis LMS in `services/oasis_lms` is a small FastAPI service that provides a WhatsApp-based learning interface. It uses a collection of "smol" agents for tasks like progress tracking, quiz generation, and teacher broadcasts. See `services/oasis_lms/README.md` for setup details.
+Oasis LMS in `services/oasis_lms` is a small FastAPI service that provides a WhatsApp-based learning interface. It uses a collection of "smol" agents for tasks like progress tracking, quiz generation, and teacher broadcasts. Teachers can now send quiz questions directly from WhatsApp and review student results. See `services/oasis_lms/README.md` for setup details.

--- a/services/oasis_lms/README.md
+++ b/services/oasis_lms/README.md
@@ -1,0 +1,46 @@
+# Oasis LMS - WhatsApp Learning Management System
+
+Oasis LMS delivers lessons and assessments through WhatsApp using a lightweight agent architecture inspired by **smolagents**. Each incoming message is processed by small, single-responsibility agents that can be combined for more advanced workflows.
+
+## Setup
+
+1. Install Python 3.10 or newer.
+2. Create and activate a virtual environment:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Configure environment variables for Twilio credentials:
+   - `TWILIO_AUTH_TOKEN`
+   - `TWILIO_ACCOUNT_SID`
+   - `TEACHER_NUMBERS` – comma-separated list of WhatsApp numbers that are treated as teachers
+
+5. Start the server:
+   ```bash
+   uvicorn app:app --host 0.0.0.0 --port 8000
+   ```
+
+Expose the `/whatsapp` endpoint to Twilio as your WhatsApp webhook URL.
+
+## Agent Overview
+- `ExtractPDFFieldsAgent` – parses PDFs and returns structured text *(stub)*
+- `GenerateQuestionsAgent` – produces quiz questions from extracted text
+- `LanguageAdapterAgent` – adapts content to the student's language
+- `ProgressTrackingAgent` – records a user's message history
+- `StudentSessionAgent` – orchestrates conversations with students
+- `TeacherSessionAgent` – allows teachers to broadcast messages and view student history
+
+These agents can be extended to call local models or external LLMs such as OpenRouter when network access is available.
+
+### Teacher Commands
+Teachers can interact with the bot from phone numbers specified in `TEACHER_NUMBERS`.
+Available commands:
+
+```
+broadcast <message>  # send a note to every student
+history <number>     # view recent messages from a student
+```

--- a/services/oasis_lms/README.md
+++ b/services/oasis_lms/README.md
@@ -1,6 +1,6 @@
 # Oasis LMS - WhatsApp Learning Management System
 
-Oasis LMS delivers lessons and assessments through WhatsApp using a lightweight agent architecture inspired by **smolagents**. Each incoming message is processed by small, single-responsibility agents that can be combined for more advanced workflows.
+Oasis LMS delivers lessons and assessments through WhatsApp using a lightweight agent architecture inspired by **smolagents**. Each incoming message is processed by small, single-responsibility agents that can be combined for more advanced workflows. Teachers can post quiz questions from WhatsApp, and students reply directly in the chat with automatic marking.
 
 ## Setup
 
@@ -41,6 +41,8 @@ Teachers can interact with the bot from phone numbers specified in `TEACHER_NUMB
 Available commands:
 
 ```
-broadcast <message>  # send a note to every student
-history <number>     # view recent messages from a student
+broadcast <message>        # send a note to every student
+history <number>           # view recent messages from a student
+ask <question>|<answer>    # distribute a quiz question
+results <number>           # see quiz results for a student
 ```

--- a/services/oasis_lms/agents.py
+++ b/services/oasis_lms/agents.py
@@ -38,6 +38,29 @@ class ProgressTrackingAgent:
         return self.history.get(user, [])
 
 
+class QuizAgent:
+    """Simple agent for distributing and grading quiz questions."""
+
+    def __init__(self) -> None:
+        self.pending: Dict[str, tuple[str, str]] = {}
+        self.results: Dict[str, List[tuple[str, str, bool]]] = {}
+
+    def distribute(self, students: List[str], question: str, answer: str) -> None:
+        for student in students:
+            self.pending[student] = (question, answer)
+
+    def answer(self, user: str, text: str) -> str:
+        question, expected = self.pending.pop(user)
+        correct = text.strip().lower() == expected.strip().lower()
+        self.results.setdefault(user, []).append((question, text, correct))
+        if correct:
+            return "Correct!"
+        return f"Incorrect. Correct answer: {expected}"
+
+    def get_results(self, user: str) -> List[tuple[str, str, bool]]:
+        return self.results.get(user, [])
+
+
 class StudentSessionAgent:
     """Main session agent coordinating other agents."""
 
@@ -46,12 +69,26 @@ class StudentSessionAgent:
         self.language_adapter = LanguageAdapterAgent()
         self.generator = GenerateQuestionsAgent()
         self.pending: Dict[str, List[str]] = {}
+        self.quiz = QuizAgent()
 
     def add_pending_message(self, user: str, msg: str) -> None:
         self.pending.setdefault(user, []).append(msg)
 
+    def add_quiz(self, question: str, answer: str) -> None:
+        students = list(
+            set(self.progress.history.keys()) | set(self.pending.keys())
+        )
+        if not students:
+            return
+        self.quiz.distribute(students, question, answer)
+        for s in students:
+            self.add_pending_message(s, f"Quiz: {question}")
+
     def handle_message(self, message: str, user: str) -> str:
         self.progress.log(user, message)
+
+        if user in self.quiz.pending:
+            return self.quiz.answer(user, message)
 
         pending = self.pending.pop(user, [])
         history_len = len(self.progress.get_history(user))
@@ -93,6 +130,25 @@ class TeacherSessionAgent:
                 self.students.add_pending_message(student, note)
             return "Broadcast sent to all students."
 
+        if lower.startswith("ask "):
+            qa = command[len("ask ") :]
+            if "|" not in qa:
+                return "Format: ask <question>|<answer>"
+            question, answer = qa.split("|", 1)
+            self.students.add_quiz(question.strip(), answer.strip())
+            return "Quiz question sent to all students."
+
+        if lower.startswith("results "):
+            number = command[len("results ") :].strip()
+            results = self.students.quiz.get_results(number)
+            if not results:
+                return f"No results for {number}."
+            lines = []
+            for i, (q, a, correct) in enumerate(results[-5:], 1):
+                status = "✅" if correct else "❌"
+                lines.append(f"{i}. {q} -> {a} {status}")
+            return "\n".join(lines)
+
         if lower.startswith("history "):
             number = command[len("history ") :].strip()
             history = self.students.progress.get_history(number)
@@ -104,5 +160,7 @@ class TeacherSessionAgent:
         return (
             "Teacher commands:\n"
             "broadcast <msg> - send a message to all students\n"
-            "history <number> - show recent messages from a student"
+            "history <number> - show recent messages from a student\n"
+            "ask <question>|<answer> - send a quiz question to students\n"
+            "results <number> - show quiz results for a student"
         )

--- a/services/oasis_lms/agents.py
+++ b/services/oasis_lms/agents.py
@@ -1,0 +1,108 @@
+from typing import List, Dict
+
+class ExtractPDFFieldsAgent:
+    """Placeholder agent that pretends to extract text from a PDF."""
+
+    def run(self, pdf_path: str) -> Dict[str, str]:
+        # In a real implementation this would parse the PDF.
+        return {"text": f"[extracted text from {pdf_path}]"}
+
+
+class GenerateQuestionsAgent:
+    """Generates quiz questions from extracted text."""
+
+    def run(self, content: Dict[str, str]) -> List[str]:
+        # Placeholder question generation.
+        text = content.get("text", "")
+        return [f"What is a key point from the text: {text[:30]}?"]
+
+
+class LanguageAdapterAgent:
+    """Adapts text to the target language (stub)."""
+
+    def run(self, text: str, language: str) -> str:
+        # For now we simply return the text unmodified.
+        return text
+
+
+class ProgressTrackingAgent:
+    """Stores a simple in-memory log of user messages."""
+
+    def __init__(self) -> None:
+        self.history: Dict[str, List[str]] = {}
+
+    def log(self, user: str, message: str) -> None:
+        self.history.setdefault(user, []).append(message)
+
+    def get_history(self, user: str) -> List[str]:
+        return self.history.get(user, [])
+
+
+class StudentSessionAgent:
+    """Main session agent coordinating other agents."""
+
+    def __init__(self) -> None:
+        self.progress = ProgressTrackingAgent()
+        self.language_adapter = LanguageAdapterAgent()
+        self.generator = GenerateQuestionsAgent()
+        self.pending: Dict[str, List[str]] = {}
+
+    def add_pending_message(self, user: str, msg: str) -> None:
+        self.pending.setdefault(user, []).append(msg)
+
+    def handle_message(self, message: str, user: str) -> str:
+        self.progress.log(user, message)
+
+        pending = self.pending.pop(user, [])
+        history_len = len(self.progress.get_history(user))
+
+        reply = (
+            f"Oasis LMS received your message: '{message}'. "
+            f"You have sent {history_len} messages so far."
+        )
+
+        if pending:
+            teacher_notes = "\n".join(pending)
+            reply = f"Teacher says: {teacher_notes}\n" + reply
+
+        return reply
+
+
+class TeacherSessionAgent:
+    """Handles teacher commands and manages student sessions."""
+
+    def __init__(self, student_agent: StudentSessionAgent) -> None:
+        self.students = student_agent
+        self.progress = ProgressTrackingAgent()
+
+    def handle_message(self, message: str, user: str) -> str:
+        self.progress.log(user, message)
+
+        command = message.strip()
+        lower = command.lower()
+
+        if lower.startswith("broadcast "):
+            note = command[len("broadcast ") :]
+            all_students = (
+                set(self.students.progress.history.keys())
+                | set(self.students.pending.keys())
+            )
+            if not all_students:
+                return "No students have interacted yet."
+            for student in all_students:
+                self.students.add_pending_message(student, note)
+            return "Broadcast sent to all students."
+
+        if lower.startswith("history "):
+            number = command[len("history ") :].strip()
+            history = self.students.progress.get_history(number)
+            if not history:
+                return f"No history for {number}."
+            last = "; ".join(history[-5:])
+            return f"Last messages from {number}: {last}"
+
+        return (
+            "Teacher commands:\n"
+            "broadcast <msg> - send a message to all students\n"
+            "history <number> - show recent messages from a student"
+        )

--- a/services/oasis_lms/app.py
+++ b/services/oasis_lms/app.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import PlainTextResponse
+from twilio.twiml.messaging_response import MessagingResponse
+from .agents import StudentSessionAgent, TeacherSessionAgent
+import os
+
+app = FastAPI(title="Oasis LMS")
+
+student_agent = StudentSessionAgent()
+teacher_agent = TeacherSessionAgent(student_agent)
+teacher_numbers = {
+    num.strip() for num in os.getenv("TEACHER_NUMBERS", "").split(",") if num.strip()
+}
+
+@app.post("/whatsapp")
+async def whatsapp_webhook(request: Request):
+    form = await request.form()
+    incoming_msg = form.get("Body", "").strip()
+    from_number = form.get("From", "")
+
+    if not incoming_msg:
+        raise HTTPException(status_code=400, detail="Missing message body")
+
+    if from_number in teacher_numbers:
+        response_text = teacher_agent.handle_message(incoming_msg, from_number)
+    else:
+        response_text = student_agent.handle_message(incoming_msg, from_number)
+    resp = MessagingResponse()
+    resp.message(response_text)
+    return PlainTextResponse(str(resp))
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", 8000)))

--- a/services/oasis_lms/requirements.txt
+++ b/services/oasis_lms/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+twilio
+python-multipart


### PR DESCRIPTION
## Summary
- restructure Oasis LMS to use small agent classes
- wire StudentSessionAgent into FastAPI app
- document agent-based design and usage
- trim dependencies for offline execution
- add teacher agent and broadcast features

## Testing
- `python3 -m py_compile services/oasis_lms/app.py services/oasis_lms/agents.py`


------
https://chatgpt.com/codex/tasks/task_e_685afe499f0083339a38b6a5e8fd5685